### PR TITLE
getting this to work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ name = "test"
 path = "test/mod.rs"
 
 [dependencies]
-discotech_zookeeper = "0.1.0"
-log = "0.3"
-log4rs = "0.3"
-mio = "0.3.0"
+zookeeper = "0.5.7"
+log = "0.4.8"
+log4rs = "0.9.0"
+mio = "0.6.21"
 rustc-serialize = "0.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct DiscoConfig {
 
 
 pub fn read_config(config_file_loc: String) -> io::Result<DiscoConfig> {
-  let mut config_file = try!(File::open(config_file_loc));
+  let mut config_file = File::open(config_file_loc)?;
   let mut config_file_contents = String::new();
   try!(config_file.read_to_string(&mut config_file_contents));
   let config: DiscoConfig = json::decode(&config_file_contents).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate log;
 extern crate log4rs;
 extern crate rustc_serialize;
-extern crate discotech_zookeeper;
+extern crate zookeeper;
 
 pub use config::{read_config, DiscoConfig};
 pub use serverset::Serverset;

--- a/src/serverset.rs
+++ b/src/serverset.rs
@@ -1,5 +1,5 @@
 extern crate log;
-extern crate discotech_zookeeper;
+extern crate zookeeper;
 
 use config::*;
 
@@ -9,9 +9,7 @@ use std::thread;
 use std::time::Duration;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use discotech_zookeeper::{Acl, CreateMode, Watcher, WatchedEvent, ZkError, ZooKeeper};
-use discotech_zookeeper::perms;
-
+use zookeeper::{Acl, CreateMode, Watcher, WatchedEvent, ZkError, ZooKeeper};
 
 #[derive(Debug, RustcDecodable, RustcEncodable)]
 pub struct ServiceEndpoint {
@@ -30,7 +28,7 @@ pub struct ServersetMember {
 
 struct NullWatcher;
 impl Watcher for NullWatcher {
-  fn handle(&self, e: &WatchedEvent) {}
+  fn handle(&self, e: WatchedEvent) {}
 }
 
 
@@ -53,7 +51,7 @@ impl Serverset {
     }
   }
 
-  pub fn watch(&self) {
+  pub fn watch(self) {
     let zk_client = self.zk_client.clone();
     thread::spawn(move || {
       self.update_members(zk_client);


### PR DESCRIPTION
I'm on MacOS and just trying to get this to build. Stuck right now on this error:

```
error[E0599]: no method named `clone` found for type `zookeeper::ZooKeeper` in the current scope
  --> src/serverset.rs:55:36
   |
55 |     let zk_client = self.zk_client.clone();
   |                                    ^^^^^ help: there is a method with a similar name: `close`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `discotech`.

To learn more, run the command again with --verbose.
```

This is odd because there is a derived implementation of `Clone`: https://docs.rs/discotech_zookeeper/0.1.0/src/discotech_zookeeper/zookeeper.rs.html#62 but `clone` still isn't recognized by the compiler as a valid method on `ZooKeeper`